### PR TITLE
Fix retrieval node bug with vectorstore

### DIFF
--- a/core/nodes/retrieval.py
+++ b/core/nodes/retrieval.py
@@ -2,9 +2,12 @@
 
 from ..vectorstore import get_vectorstore
 
+
 def retrieval_node(state: dict) -> dict:
-    query = state['input']
-    model_name = state.get("embedding_model")
+    query = state["input"]
+    # The embedding model name is populated by the previous node under
+    # ``embedding_model_name``. Use that value if present.
+    model_name = state.get("embedding_model_name")
 
     vectorstore = get_vectorstore(embedding_model_name=model_name)
     retriever = vectorstore.as_retriever(search_type="similarity", k=5)

--- a/core/vectorstore.py
+++ b/core/vectorstore.py
@@ -1,11 +1,18 @@
 # vectorstore.py
 
 from langchain_community.vectorstores import Chroma
+from .embedding import get_embedding_model
 from config import CHROMA_PERSIST_DIR, CHROMA_COLLECTION_NAMESPACE
 
 
-def get_vectorstore():
+def get_vectorstore(embedding_model_name: str | None = None) -> Chroma:
+    """Return a Chroma vector store configured with the optional embedding model."""
+    embedding_model = None
+    if embedding_model_name:
+        embedding_model = get_embedding_model(embedding_model_name)
+
     return Chroma(
         persist_directory=CHROMA_PERSIST_DIR,
         collection_name=CHROMA_COLLECTION_NAMESPACE,
+        embedding_function=embedding_model,
     )


### PR DESCRIPTION
## Summary
- fix retrieval node to use `embedding_model_name`
- allow `get_vectorstore` to accept an embedding model name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fbb88fe2483218364cb6576031946