### PR TITLE
Fix retrieval node embedding handling

### DIFF
--- a/core/nodes/retrieval.py
+++ b/core/nodes/retrieval.py
@@ -4,7 +4,7 @@ from ..vectorstore import get_vectorstore
 
 def retrieval_node(state: dict) -> dict:
     query = state['input']
-    model_name = state.get("embedding_model")
+    model_name = state.get("embedding_model_name")
 
     vectorstore = get_vectorstore(embedding_model_name=model_name)
     retriever = vectorstore.as_retriever(search_type="similarity", k=5)

--- a/core/vectorstore.py
+++ b/core/vectorstore.py
@@ -1,11 +1,15 @@
 # vectorstore.py
 
 from langchain_community.vectorstores import Chroma
+from .embedding import get_embedding_model
 from config import CHROMA_PERSIST_DIR, CHROMA_COLLECTION_NAMESPACE
 
 
-def get_vectorstore():
+def get_vectorstore(embedding_model_name: str | None = None) -> Chroma:
+    """Return a Chroma vector store using the specified embedding model."""
+    embedding = get_embedding_model(embedding_model_name or "bge-en-icl")
     return Chroma(
         persist_directory=CHROMA_PERSIST_DIR,
         collection_name=CHROMA_COLLECTION_NAMESPACE,
+        embedding_function=embedding,
     )


### PR DESCRIPTION
## Summary
- fix retrieval node to use correct embedding model key
- allow vectorstore to select embedding model

## Testing
- `python -m py_compile core/nodes/retrieval.py core/vectorstore.py`

------
https://chatgpt.com/codex/tasks/task_e_683fbbaa2da483218a2a887e91b00c5f