### PR TITLE
Fix missing redis dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ Here’s a detailed and professional summary of your **Owlin** project suitable 
 
 Instructions to run with:
 
+* Install Python dependencies:
+  ```bash
+  pip install -r backend/requirements.txt
+  ```
+  This includes the `langgraph-checkpoint-redis` package required for
+  Redis-based checkpointing.
+
 * Docker (for Redis + ChromaDB)
 * Python (venv, FastAPI backend)
 * Local inference using `llama-cpp-python`

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -69,6 +69,7 @@ langchain-redis==0.2.1
 langchain-text-splitters==0.3.8
 langgraph==0.4.7
 langgraph-checkpoint==2.0.26
+langgraph-checkpoint-redis==0.0.6
 langgraph-prebuilt==0.2.2
 langgraph-sdk==0.1.70
 langsmith==0.3.43


### PR DESCRIPTION
## Summary
- add langgraph-checkpoint-redis to backend requirements
- document installing backend dependencies in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840966dbbf08321a583082cba9aebae